### PR TITLE
[AS8-1161] Move the build to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,5 @@
 language: minimal
 
-env:
-  - VERSION=316
-  - VERSION=317 ISLATEST=1
-
 script:
-  - docker build --build-arg PRESTO_VERSION=${VERSION} -t simplifi/docker-presto .
-  - docker tag simplifi/docker-presto simplifi/docker-presto:${VERSION}
-  - docker run simplifi/docker-presto:${VERSION} /usr/lib/presto/bin/launcher --help
-
-before_deploy:
-  - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD} ;
-
-# Deploy to Docker Hub
-deploy:
-  # Always push the versioned tag
-  - provider: script
-    script: bash docker push simplifi/docker-presto:${VERSION} ;
-    on:
-      branch: master
-      repo: simplifi/docker-presto
-
-  # Only push the latest tag if this is the latest version
-  - provider: script
-    script: bash docker push simplifi/docker-presto:latest ;
-    on:
-      branch: master
-      repo: simplifi/docker-presto
-      condition: $ISLATEST = 1
+  - docker build -t simplifi/docker-presto .
+  - docker run simplifi/docker-presto /usr/lib/presto/bin/launcher --help

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # docker-presto
 
-[![Build Status](https://travis-ci.com/simplifi/docker-presto.svg?branch=master)](https://travis-ci.com/simplifi/docker-presto)
+[![Travis Build Status](https://travis-ci.com/simplifi/docker-presto.svg?branch=master)](https://travis-ci.com/simplifi/docker-presto)
+[![Docker Build Status](https://img.shields.io/docker/build/simplifi/docker-presto.svg)](https://cloud.docker.com/u/simplifi/repository/docker/simplifi/docker-presto/builds)
 [![Docker Hub](https://img.shields.io/badge/docker-ready-blue.svg)](https://hub.docker.com/r/simplifi/docker-presto/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/simplifi/docker-presto.svg)](https://hub.docker.com/r/simplifi/docker-presto/)
 [![Docker Stars](https://img.shields.io/docker/stars/simplifi/docker-presto.svg)](https://hub.docker.com/r/simplifi/docker-presto/)


### PR DESCRIPTION
It seems like we'll get better visibility into our builds, and an auto readme sync if we use dockerhub for builds.

Pairing down the travis config, and adding the button for the dockerhub build.

To deploy, we'll need to bump the presto version in the Dockerfile and then create a release or tag in git, which will trigger the build in dockerhub.