### PR TITLE
Fix coordinator properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ docker run -p 8080:8080 simplifi/docker-presto:latest
 
 Configuration is handled by setting the environment variables outlined below.
 
-### jvm.config
-
-| Property         | Environment Variable    | Default Value                 | Description                                                    |
-| -----------------| ----------------------- | ----------------------------- | -------------------------------------------------------------- |
-| Xmx              | PRESTO_JVM_XMX_GB       | 16                            | the maximum size, in gigabytes, of the memory allocation pool. |
-
 
 ### node.properties
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # docker-presto
 
 [![Travis Build Status](https://travis-ci.com/simplifi/docker-presto.svg?branch=master)](https://travis-ci.com/simplifi/docker-presto)
-[![Docker Build Status](https://img.shields.io/docker/build/simplifi/docker-presto.svg)](https://cloud.docker.com/u/simplifi/repository/docker/simplifi/docker-presto/builds)
 [![Docker Hub](https://img.shields.io/badge/docker-ready-blue.svg)](https://hub.docker.com/r/simplifi/docker-presto/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/simplifi/docker-presto.svg)](https://hub.docker.com/r/simplifi/docker-presto/)
 [![Docker Stars](https://img.shields.io/docker/stars/simplifi/docker-presto.svg)](https://hub.docker.com/r/simplifi/docker-presto/)
@@ -31,6 +30,12 @@ docker run -p 8080:8080 simplifi/docker-presto:latest
 ## Configuration
 
 Configuration is handled by setting the environment variables outlined below.
+
+### jvm.config
+
+| Property         | Environment Variable    | Default Value                 | Description                                                    |
+| -----------------| ----------------------- | ----------------------------- | -------------------------------------------------------------- |
+| Xmx              | PRESTO_JVM_XMX_GB       | 16                            | the maximum size, in gigabytes, of the memory allocation pool. |
 
 
 ### node.properties

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,9 +5,6 @@ set -e
 #############################
 # Default Values
 
-# jvm
-: "${PRESTO_JVM_XMX_GB:=16}"
-
 # node
 : "${PRESTO_NODE_ENVIRONMENT:=docker}"
 : "${PRESTO_NODE_ID:=$(uuidgen)}"
@@ -39,25 +36,6 @@ set -e
 : "${PRESTO_CATALOG_HIVE_S3_ENDPOINT:=}"
 : "${PRESTO_CATALOG_HIVE_S3_USE_INSTANCE_CREDENTIALS:=false}"
 : "${PRESTO_CATALOG_HIVE_S3_SELECT_PUSHDOWN_ENABLED:=true}"
-
-
-#############################
-# jvm.config
-
-{   
-    echo "-server"
-    echo "-Xmx${PRESTO_JVM_XMX_GB}"
-    echo "-XX:-UseBiasedLocking"
-    echo "-XX:+UseG1GC"
-    echo "-XX:G1HeapRegionSize=32M"
-    echo "-XX:+ExplicitGCInvokesConcurrent"
-    echo "-XX:+ExitOnOutOfMemoryError"
-    echo "-XX:+UseGCOverheadLimit"
-    echo "-XX:+HeapDumpOnOutOfMemoryError"
-    echo "-XX:ReservedCodeCacheSize=512M"
-    echo "-Djdk.attach.allowAttachSelf=true"
-    echo "-Djdk.nio.maxCachedBufferSize=2000000"
-} > /etc/presto/jvm.config
 
 
 #############################


### PR DESCRIPTION
The entrypoint script was writing out coordinator properties on the workers, which resulted in the workers being unable to start.  This PR fixes that, and also adds in the ability to adjust the JVM memory.